### PR TITLE
feat: use In App Billing v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# Titanium In-App-Purchasing
+# Titanium In-App-Purchases
 
-Support for native cross-platform in-app-purchasing API's in Titanium.
+Support for native cross-platform in-app-purchase API's in Titanium.
 This repository represents a modern alternative to ti.storekit (iOS) and ti.inappbilling (Android). 
+
+## Versions
+
+- Android: In App Billing v6 (6.0.1)
+- iOS: SwiftyStoreKit 0.16.4
 
 ## Requirements
 
-- [x] iOS 11+
-- [x] Android 5+
 - [x] Titanium SDK 9.2.0+
 
 ## Example

--- a/android/Resources/README.md
+++ b/android/Resources/README.md
@@ -1,8 +1,0 @@
-Files in this folder are copied directory into the compiled product directory
-when the Android app is compiled:
-
-    <project-dir>/build/android/bin/assets/Resources/
-
-Files in this directory are copied directly on top of whatever files are already
-in the build directory, so please be careful that your files don't clobber
-essential project files or files from other modules.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,9 @@
 apply plugin: "kotlin-android"
-apply plugin: "kotlin-android-extensions"
 
 dependencies {
 	implementation "androidx.core:core-ktx:1.3.0"
 
-	def inapp_version = "5.0.0"
+	def inapp_version = "6.0.1"
     implementation "com.android.billingclient:billing:${inapp_version}"
     implementation "com.android.billingclient:billing-ktx:${inapp_version}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: "kotlin-android"
 dependencies {
 	implementation "androidx.core:core-ktx:1.3.0"
 
-	def inapp_version = "6.0.1"
+	def inapp_version = "7.0.0"
     implementation "com.android.billingclient:billing:${inapp_version}"
     implementation "com.android.billingclient:billing-ktx:${inapp_version}"
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.2
+version: 4.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-in-app-purchase

--- a/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
+++ b/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
@@ -179,9 +179,9 @@ class TitaniumInAppPurchaseModule : KrollModule() {
         }
 
         val productId = params.getString("identifier")
-        val oldPurchaseToken = params.getString("oldPurchaseToken")
-        val subscriptionReplacementMode = params.getInt("subscriptionReplacementMode")
-        val originalExternalTransactionId = params.getString("originalExternalTransactionId")
+        val oldPurchaseToken = params.optString("oldPurchaseToken", null)
+        val subscriptionReplacementMode = params.optInt("subscriptionReplacementMode", -1)
+        val originalExternalTransactionId = params.optString("originalExternalTransactionId", null)
 
         val skuDetails = ProductsHandler.getSkuDetails(productId) ?: return CODE_SKU_NOT_AVAILABLE
         var flowParams = BillingFlowParams.newBuilder().setSkuDetails(skuDetails)
@@ -190,11 +190,11 @@ class TitaniumInAppPurchaseModule : KrollModule() {
         if (oldPurchaseToken != null) {
             var params = SubscriptionUpdateParams.newBuilder().setOldPurchaseToken(oldPurchaseToken)
 
-            if (subscriptionReplacementMode != null) {
+            if (subscriptionReplacementMode != -1) {
                 params = params.setSubscriptionReplacementMode(subscriptionReplacementMode);
             }
 
-            if (subscriptionReplacementMode != null) {
+            if (originalExternalTransactionId != null) {
                 params = params.setOriginalExternalTransactionId(originalExternalTransactionId);
             }
 

--- a/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
+++ b/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
@@ -62,8 +62,8 @@ class TitaniumInAppPurchaseModule : KrollModule() {
         @Kroll.constant const val CODE_ITEM_NOT_OWNED = ITEM_NOT_OWNED                  // "Failure to consume since item is not owned."
         @Kroll.constant const val CODE_ITEM_UNAVAILABLE = ITEM_UNAVAILABLE              // "Requested product is not available for purchase."
         @Kroll.constant const val CODE_SERVICE_DISCONNECTED = SERVICE_DISCONNECTED      // "Play Store service is not connected now - potentially transient state."
-        @Kroll.constant const val CODE_SERVICE_TIMEOUT = SERVICE_TIMEOUT                // "The request has reached the maximum timeout before Google Play responds."
         @Kroll.constant const val CODE_SERVICE_UNAVAILABLE = SERVICE_UNAVAILABLE        // "Network connection is down."
+        @Kroll.constant const val CODE_NETWORK_ERROR = NETWORK_ERROR                    // "Network connection is down."
         @Kroll.constant const val CODE_USER_CANCELED = USER_CANCELED                    // "User pressed back or canceled dialog."
         @Kroll.constant const val CODE_ERROR = ERROR                                    // "Fatal error during the API action."
         @Kroll.constant const val CODE_OK = OK

--- a/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
+++ b/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
@@ -123,7 +123,7 @@ class TitaniumInAppPurchaseModule : KrollModule() {
 
     @Kroll.method
     fun launchPriceChangeConfirmationFlow(args: KrollDict) {
-        org.appcelerator.kroll.common.Log.e("Ti.IAP", "The \"launchPriceChangeConfirmationFlow\" method was removed in In App Billing v6")
+        Log.e("Ti.IAP", "The \"launchPriceChangeConfirmationFlow\" method was removed in In App Billing v6. Use the properties \"oldPurchaseToken\", \"subscriptionReplacementMode\" and \"originalExternalTransactionId\" in \"purchase()\" instead!")
     }
 
     private fun isBillingLibraryReady(args: KrollDict? = null): Boolean {
@@ -254,7 +254,7 @@ class TitaniumInAppPurchaseModule : KrollModule() {
 
     @Kroll.method
     fun queryPurchasesAsync(args: KrollDict) {
-        Log.e("Ti.IAP", "The \"queryPurchasesAsync\" API has been removed, use the properties \"oldPurchaseToken\", \"subscriptionReplacementMode\" and \"originalExternalTransactionId\" in \"purchase()\" instead!")
+        Log.e("Ti.IAP", "The \"queryPurchasesAsync\" API has been removed. Use \"queryPurchases\" instead!")
     }
 
     @Kroll.method

--- a/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
+++ b/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
@@ -10,15 +10,18 @@
 
 package ti.iap
 
-import android.util.Log
 import com.android.billingclient.api.*
 import com.android.billingclient.api.BillingClient.BillingResponseCode.*
 import com.android.billingclient.api.BillingClient.FeatureType.*
 import com.android.billingclient.api.BillingClient.SkuType.INAPP
 import com.android.billingclient.api.BillingClient.SkuType.SUBS
+import com.android.billingclient.api.BillingFlowParams.ProrationMode
+import com.android.billingclient.api.BillingFlowParams.SubscriptionUpdateParams
+import com.android.billingclient.api.BillingFlowParams.SubscriptionUpdateParams.ReplacementMode
 import com.android.billingclient.api.Purchase.PurchaseState.*
 import org.appcelerator.kroll.KrollDict
 import org.appcelerator.kroll.KrollFunction
+import org.appcelerator.kroll.common.Log
 import org.appcelerator.kroll.KrollModule
 import org.appcelerator.kroll.KrollProxy
 import org.appcelerator.kroll.annotations.Kroll
@@ -28,10 +31,7 @@ import ti.iap.handlers.ProductsHandler
 import ti.iap.handlers.PurchaseHandler
 import ti.iap.helper.QueryHandler
 import ti.iap.models.PurchaseModel
-import java.lang.Error
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
+
 
 @Kroll.module(name = "TitaniumInAppPurchase", id = "ti.iap")
 class TitaniumInAppPurchaseModule : KrollModule() {
@@ -69,6 +69,13 @@ class TitaniumInAppPurchaseModule : KrollModule() {
         @Kroll.constant const val CODE_OK = OK
         @Kroll.constant const val CODE_BILLING_NOT_READY = 100                          // "Billing library not ready"
         @Kroll.constant const val CODE_SKU_NOT_AVAILABLE = 101                          // "SKU details not available for making purchase"
+
+        @Kroll.constant const val REPLACEMENT_MODE_CHARGE_FULL_PRICE = ReplacementMode.CHARGE_FULL_PRICE
+        @Kroll.constant const val REPLACEMENT_MODE_UNKNOWN_REPLACEMENT_MODE = ReplacementMode.UNKNOWN_REPLACEMENT_MODE
+        @Kroll.constant const val REPLACEMENT_MODE_CHARGE_PRORATED_PRICE = ReplacementMode.CHARGE_PRORATED_PRICE
+        @Kroll.constant const val REPLACEMENT_MODE_WITHOUT_PRORATION = ReplacementMode.WITHOUT_PRORATION
+        @Kroll.constant const val REPLACEMENT_MODE_WITH_TIME_PRORATION = ReplacementMode.WITH_TIME_PRORATION
+        @Kroll.constant const val REPLACEMENT_MODE_DEFERRED = ReplacementMode.DEFERRED
     }
 
     @Kroll.method
@@ -116,20 +123,7 @@ class TitaniumInAppPurchaseModule : KrollModule() {
 
     @Kroll.method
     fun launchPriceChangeConfirmationFlow(args: KrollDict) {
-        val callback = args[IAPConstants.Properties.CALLBACK] as KrollFunction?
-        val productId = args[IAPConstants.PurchaseModelKeys.PRODUCT_ID] as String
-        val skuDetails = ProductsHandler.getSkuDetails(productId) ?: return
-
-        org.appcelerator.kroll.common.Log.w("Ti.IAP", "The \"launchPriceChangeConfirmationFlow\" method has been deprecated by Google and may be removed in the future.")
-
-        val params = PriceChangeFlowParams.newBuilder().setSkuDetails(skuDetails).build()
-        billingClient?.launchPriceChangeConfirmationFlow(TiApplication.getInstance().rootOrCurrentActivity, params) { billingResult ->
-            val event = KrollDict()
-            event[IAPConstants.Properties.SUCCESS] = billingResult.responseCode == OK
-            event[IAPConstants.Properties.CODE] = billingResult.responseCode
-
-            callback?.callAsync(getKrollObject(), event)
-        }
+        org.appcelerator.kroll.common.Log.e("Ti.IAP", "The \"launchPriceChangeConfirmationFlow\" method was removed in In App Billing v6")
     }
 
     private fun isBillingLibraryReady(args: KrollDict? = null): Boolean {
@@ -179,15 +173,35 @@ class TitaniumInAppPurchaseModule : KrollModule() {
     }
 
     @Kroll.method
-    fun purchase(productId: String): Int {
+    fun purchase(params: KrollDict): Int {
         if (!isBillingLibraryReady()) {
             return CODE_BILLING_NOT_READY
         }
 
-        val skuDetails = ProductsHandler.getSkuDetails(productId) ?: return CODE_SKU_NOT_AVAILABLE
+        val productId = params.getString("identifier")
+        val oldPurchaseToken = params.getString("oldPurchaseToken")
+        val subscriptionReplacementMode = params.getInt("subscriptionReplacementMode")
+        val originalExternalTransactionId = params.getString("originalExternalTransactionId")
 
-        val flowParams = BillingFlowParams.newBuilder().setSkuDetails(skuDetails).build()
-        val launchBillingResult = billingClient!!.launchBillingFlow(TiApplication.getAppCurrentActivity(), flowParams)
+        val skuDetails = ProductsHandler.getSkuDetails(productId) ?: return CODE_SKU_NOT_AVAILABLE
+        var flowParams = BillingFlowParams.newBuilder().setSkuDetails(skuDetails)
+
+        // Handle subscription updates
+        if (oldPurchaseToken != null) {
+            var params = SubscriptionUpdateParams.newBuilder().setOldPurchaseToken(oldPurchaseToken)
+
+            if (subscriptionReplacementMode != null) {
+                params = params.setSubscriptionReplacementMode(subscriptionReplacementMode);
+            }
+
+            if (subscriptionReplacementMode != null) {
+                params = params.setOriginalExternalTransactionId(originalExternalTransactionId);
+            }
+
+            flowParams = flowParams.setSubscriptionUpdateParams(params.build())
+        }
+
+        val launchBillingResult = billingClient!!.launchBillingFlow(TiApplication.getAppCurrentActivity(), flowParams.build())
 
         return launchBillingResult.responseCode
     }
@@ -240,7 +254,7 @@ class TitaniumInAppPurchaseModule : KrollModule() {
 
     @Kroll.method
     fun queryPurchasesAsync(args: KrollDict) {
-        org.appcelerator.kroll.common.Log.e("Ti.IAP", "The \"queryPurchasesAsync\" API has been removed, use \"queryPurchases\" instead!")
+        Log.e("Ti.IAP", "The \"queryPurchasesAsync\" API has been removed, use the properties \"oldPurchaseToken\", \"subscriptionReplacementMode\" and \"originalExternalTransactionId\" in \"purchase()\" instead!")
     }
 
     @Kroll.method

--- a/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
+++ b/android/src/ti/iap/TitaniumInAppPurchaseModule.kt
@@ -15,7 +15,6 @@ import com.android.billingclient.api.BillingClient.BillingResponseCode.*
 import com.android.billingclient.api.BillingClient.FeatureType.*
 import com.android.billingclient.api.BillingClient.SkuType.INAPP
 import com.android.billingclient.api.BillingClient.SkuType.SUBS
-import com.android.billingclient.api.BillingFlowParams.ProrationMode
 import com.android.billingclient.api.BillingFlowParams.SubscriptionUpdateParams
 import com.android.billingclient.api.BillingFlowParams.SubscriptionUpdateParams.ReplacementMode
 import com.android.billingclient.api.Purchase.PurchaseState.*

--- a/android/src/ti/iap/handlers/ProductsHandler.kt
+++ b/android/src/ti/iap/handlers/ProductsHandler.kt
@@ -7,6 +7,7 @@ import com.android.billingclient.api.SkuDetailsResponseListener
 import org.appcelerator.kroll.KrollDict
 import org.appcelerator.kroll.KrollFunction
 import org.appcelerator.kroll.KrollObject
+import org.appcelerator.kroll.common.Log
 import ti.iap.IAPConstants
 import ti.iap.models.SkuModel
 
@@ -16,6 +17,9 @@ class ProductsHandler(private val callback: KrollFunction?, private val krollObj
 
         @JvmStatic fun getSkuDetails(productId: String): SkuDetails? {
             var skuDetails: SkuDetails? = null
+
+            Log.w("IAP", productId);
+            Log.w("IAP", skuList.toString());
 
             for (skuModel in skuList) {
                 if (skuModel.skuDetails.sku == productId) {

--- a/example/iap-manager.js
+++ b/example/iap-manager.js
@@ -7,7 +7,6 @@ const InAppPurchaseProduct = {
 
 let purchaseResolver;
 let purchaseRejecter;
-let tripId;
 let selectedProduct;
 
 let isBillingInitialized = false;
@@ -88,9 +87,7 @@ export default class InAppPurchaseManager {
 		}
 	}
 
-	static async purchase(product, _tripId) {
-		tripId = _tripId;
-
+	static async purchase(product) {
 		Ti.API.warn(`** Purchasing in app product (${product.identifier}) **`);
 
 		return new Promise((resolve, reject) => {
@@ -105,7 +102,13 @@ export default class InAppPurchaseManager {
 
 				selectedProduct = product;
 
-				IAP.purchase(product.identifier); // TODO: Use a callback here as well?
+				IAP.purchase({
+					identifier: product.identifier,
+					// Optional: pass subscription update parameters
+					// oldPurchaseToken: '',
+					// subscriptionReplacementMode: IAP.REPLACEMENT_MODE_CHARGE_FULL_PRICE,
+					// originalExternalTransactionId: ''
+				});
 			} else {
 				IAP.purchase({
 					identifier: product.identifier,


### PR DESCRIPTION
## Breaking Changes

- The `purchase` method now uses an object, not String.
```diff
- purchase(productId);
+ purchase({ identifier: productId });
```
- The `launchPriceChangeConfirmationFlow` method has been removed, because it was removed from the In App Billing SDK v6. Please use the new properties `oldPurchaseToken`, `subscriptionReplacementMode` and `originalExternalTransactionId` in `purchase()` instead!

Download: [ti.iap-android-4.0.0.zip](https://github.com/user-attachments/files/16160084/ti.iap-android-4.0.0.zip)

If you use this version, please leave a comment below to let me know if all works!